### PR TITLE
Refactor Trello driver

### DIFF
--- a/app/application.js
+++ b/app/application.js
@@ -57,8 +57,6 @@ function renderMetrics(isLogged$, vtree$) {
 }
 
 function main({ DOMControls, DOMMetrics, Trello, Storage }) {
-  const publishedTrelloCardsActions$$ = Trello.cardsActions$$.publish();
-
   const trelloLists$ = Trello.get('lists').startWith([]);
   const trelloActions$ = Trello.get('actions').startWith([]);
 
@@ -117,7 +115,7 @@ function main({ DOMControls, DOMMetrics, Trello, Storage }) {
     actions$: trelloActions$,
     dates$: controls.selectedDates$,
     lists$: trelloDisplayedLists$,
-    complementaryActions$: publishedTrelloCardsActions$$
+    complementaryActions$: Trello.get('cardsActions')
       .switch()
       .startWith([])
       .scan(R.concat),
@@ -126,9 +124,6 @@ function main({ DOMControls, DOMMetrics, Trello, Storage }) {
   // Download button clicks
 
   const downloadClicks$ = DOMMetrics.select('.download-btn').events('click');
-
-  // Connect
-  publishedTrelloCardsActions$$.connect();
 
   return {
     DOMControls: renderControls(isLogged$, controls.DOM),

--- a/app/application.js
+++ b/app/application.js
@@ -58,11 +58,10 @@ function renderMetrics(isLogged$, vtree$) {
 
 function main({ DOMControls, DOMMetrics, Trello, Storage }) {
   const publishedTrelloLists$ = Trello.lists$.publish();
-  const publishedTrelloActions$ = Trello.actions$.publish();
   const publishedTrelloCardsActions$$ = Trello.cardsActions$$.publish();
 
   const trelloLists$ = publishedTrelloLists$.startWith([]);
-  const trelloActions$ = publishedTrelloActions$.startWith([]);
+  const trelloActions$ = Trello.get('actions').startWith([]);
 
   // Authorization (= Trello login).
 
@@ -131,7 +130,6 @@ function main({ DOMControls, DOMMetrics, Trello, Storage }) {
 
   // Connect
   publishedTrelloLists$.connect();
-  publishedTrelloActions$.connect();
   publishedTrelloCardsActions$$.connect();
 
   return {

--- a/app/application.js
+++ b/app/application.js
@@ -81,7 +81,7 @@ function main({ DOMControls, DOMMetrics, Trello, Storage }) {
 
   const controls = Controls({
     DOM: DOMControls,
-    boards$: Trello.boards$,
+    boards$: Trello.get('boards'),
     lists$: trelloLists$,
     Storage,
   });

--- a/app/application.js
+++ b/app/application.js
@@ -57,7 +57,6 @@ function renderMetrics(isLogged$, vtree$) {
 }
 
 function main({ DOMControls, DOMMetrics, Trello, Storage }) {
-  const publishedTrelloAuthorize$ = Trello.authorize$.publish();
   const publishedTrelloLists$ = Trello.lists$.publish();
   const publishedTrelloActions$ = Trello.actions$.publish();
   const publishedTrelloCardsActions$$ = Trello.cardsActions$$.publish();
@@ -67,7 +66,7 @@ function main({ DOMControls, DOMMetrics, Trello, Storage }) {
 
   // Authorization (= Trello login).
 
-  const isLogged$ = publishedTrelloAuthorize$.map(true).startWith(false);
+  const isLogged$ = Trello.get('authorize').map(true).startWith(false);
   const authorize$ = DOMControls.select('.auth-btn')
     .events('click')
     .map(R.always({ type: 'authorize' }))
@@ -131,7 +130,6 @@ function main({ DOMControls, DOMMetrics, Trello, Storage }) {
   const downloadClicks$ = DOMMetrics.select('.download-btn').events('click');
 
   // Connect
-  publishedTrelloAuthorize$.connect();
   publishedTrelloLists$.connect();
   publishedTrelloActions$.connect();
   publishedTrelloCardsActions$$.connect();

--- a/app/application.js
+++ b/app/application.js
@@ -57,10 +57,9 @@ function renderMetrics(isLogged$, vtree$) {
 }
 
 function main({ DOMControls, DOMMetrics, Trello, Storage }) {
-  const publishedTrelloLists$ = Trello.lists$.publish();
   const publishedTrelloCardsActions$$ = Trello.cardsActions$$.publish();
 
-  const trelloLists$ = publishedTrelloLists$.startWith([]);
+  const trelloLists$ = Trello.get('lists').startWith([]);
   const trelloActions$ = Trello.get('actions').startWith([]);
 
   // Authorization (= Trello login).
@@ -129,7 +128,6 @@ function main({ DOMControls, DOMMetrics, Trello, Storage }) {
   const downloadClicks$ = DOMMetrics.select('.download-btn').events('click');
 
   // Connect
-  publishedTrelloLists$.connect();
   publishedTrelloCardsActions$$.connect();
 
   return {

--- a/app/application.js
+++ b/app/application.js
@@ -4,7 +4,7 @@ import storageDriver from '@cycle/storage';
 import { Observable } from 'rx';
 import R from 'ramda';
 
-import { trelloSinkDriver } from './drivers/Trello';
+import { makeTrelloSinkDriver } from './drivers/Trello';
 import { makeGraphDriver } from './drivers/Graph';
 import { exportToCSVDriver } from './drivers/ExportToCSV';
 
@@ -146,7 +146,7 @@ function main({ DOMControls, DOMMetrics, Trello, Storage }) {
 const drivers = {
   DOMControls: makeDOMDriver('#controls'),
   DOMMetrics: makeDOMDriver('#metrics'),
-  Trello: trelloSinkDriver,
+  Trello: makeTrelloSinkDriver('Trello Kanban Analysis Tool'),
   Graph: makeGraphDriver('#chart svg'),
   Storage: storageDriver,
   ExportToCSV: exportToCSVDriver,

--- a/app/drivers/Trello.js
+++ b/app/drivers/Trello.js
@@ -138,28 +138,28 @@ function createCardsActions$$(input$) {
   });
 }
 
-function trelloSinkDriver(input$) {
-  const appName = 'Trello Kanban Analysis Tool';
+function makeTrelloSinkDriver(appName) {
+  return (input$) => {
+    const factories = {
+      authorize: createAuthorize$(appName, input$).publish(),
+      boards: createBoards$(input$),
+      actions: createActions$(input$).publish(),
+      lists: createLists$(input$).publish(),
+      cardsActions: createCardsActions$$(input$).publish(),
+    };
 
-  const factories = {
-    authorize: createAuthorize$(appName, input$).publish(),
-    boards: createBoards$(input$),
-    actions: createActions$(input$).publish(),
-    lists: createLists$(input$).publish(),
-    cardsActions: createCardsActions$$(input$).publish(),
-  };
+    // Connect hot observables so they start emitting.
+    factories.authorize.connect();
+    factories.actions.connect();
+    factories.lists.connect();
+    factories.cardsActions.connect();
 
-  // Connect hot observables so they start emitting.
-  factories.authorize.connect();
-  factories.actions.connect();
-  factories.lists.connect();
-  factories.cardsActions.connect();
-
-  return {
-    get(type) {
-      return factories[type];
-    },
+    return {
+      get(type) {
+        return factories[type];
+      },
+    };
   };
 }
 
-export { trelloSinkDriver };
+export { makeTrelloSinkDriver };

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tkat",
-  "version": "0.6.0",
+  "version": "0.7.0",
   "description": "Analyse Kanban metrics from a Trello board",
   "keywords": [
     "trello",


### PR DESCRIPTION
Will close #7.

What have changed here:

- expose a single `.get()` method that will return an Observable. This follows Cycle.js docs -> driver should return either an Observable or a queryable collection of Observables.
- refactor management of hot observables back into the driver to simplify usage from the application point of view.
- pass the application name as a parameter, making the driver a bit cleaner.